### PR TITLE
Repository nullables and EDIParser refactor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
   ],
   "require": {
     "myclabs/php-enum": "^1.6",
-    "psr/container": "^1.0"
+    "psr/container": "^1.0",
+    "nesbot/carbon": "~1.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/Enums/Messages.php
+++ b/src/Enums/Messages.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace SIVI\AFD\Enums;
-
 
 use MyCLabs\Enum\Enum;
 
@@ -15,4 +13,6 @@ class Messages extends Enum
     public const GROUP = 'Groepsdocument';
     public const DAMAGE = 'Schadedocument';
     public const DAMGEINVOICE = 'Schadefactuur';
+    public const PROLONGATION = 'Prolongatie';
+    public const MUTATION = 'Mutatie';
 }

--- a/src/Exceptions/EDIException.php
+++ b/src/Exceptions/EDIException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace SIVI\AFD\Exceptions;
+
+use Exception;
+
+class AFDException extends Exception
+{
+
+}

--- a/src/Exceptions/EDIException.php
+++ b/src/Exceptions/EDIException.php
@@ -4,7 +4,7 @@ namespace SIVI\AFD\Exceptions;
 
 use Exception;
 
-class AFDException extends Exception
+class EDIException extends Exception
 {
 
 }

--- a/src/Models/Contracts/Message.php
+++ b/src/Models/Contracts/Message.php
@@ -4,8 +4,16 @@
 namespace SIVI\AFD\Models\Contracts;
 
 
+use Carbon\Carbon;
+
 interface Message
 {
+
+    /**
+     * @return int
+     */
+    public function getSubMessagesCount(): int;
+
     /**
      * @param $label
      * @return bool
@@ -32,4 +40,44 @@ interface Message
      * @return bool
      */
     public static function matchMessage(Message $message): bool;
+
+    /**
+     * @return Carbon|null
+     */
+    public function getDateTime(): ?Carbon;
+
+    /**
+     * @param Carbon $dateTime
+     */
+    public function setDateTime(Carbon $dateTime): void;
+
+    /**
+     * @return string|null
+     */
+    public function getMessageId(): ?string;
+
+    /**
+     * @param string $messageId
+     */
+    public function setMessageId(string $messageId): void;
+
+    /**
+     * @return string|null
+     */
+    public function getSender(): ?string;
+
+    /**
+     * @param string $sender
+     */
+    public function setSender(string $sender): void;
+
+    /**
+     * @return string|null
+     */
+    public function getReceiver(): ?string;
+
+    /**
+     * @param string $receiver
+     */
+    public function setReceiver(string $receiver): void;
 }

--- a/src/Models/Message.php
+++ b/src/Models/Message.php
@@ -3,6 +3,7 @@
 namespace SIVI\AFD\Models;
 
 
+use Carbon\Carbon;
 use SIVI\AFD\Models\Contracts\Message as MessageContract;
 use SIVI\AFD\Models\Interfaces\Validatable;
 use SIVI\AFD\Models\Messages\BatchMessage;
@@ -13,37 +14,47 @@ class Message implements MessageContract, Validatable
     /**
      * @var string
      */
-    protected $label;
-
-    /**
-     * @var string
-     */
     protected static $type;
-
-    /**
-     * @var array
-     */
-    protected $entities = [];
-
-    /**
-     * @var array
-     */
-    protected $allowedEntities = [];
-
-    /**
-     * @var array
-     */
-    protected $subMessages = [];
-
-    /**
-     * @var array
-     */
-    protected $allowedSubMessages = [];
-
     protected static $typeMap = [
         ContractMessage::class,
         BatchMessage::class
     ];
+    /**
+     * @var string
+     */
+    protected $label;
+    /**
+     * @var array
+     */
+    protected $entities = [];
+    /**
+     * @var array
+     */
+    protected $allowedEntities = [];
+    /**
+     * @var array
+     */
+    protected $subMessages = [];
+    /**
+     * @var string
+     */
+    protected $sender;
+    /**
+     * @var string
+     */
+    protected $receiver;
+    /**
+     * @var Carbon
+     */
+    protected $dateTime;
+    /**
+     * @var string
+     */
+    protected $messageId;
+    /**
+     * @var array
+     */
+    protected $allowedSubMessages = [];
 
     /**
      * Message constructor.
@@ -72,6 +83,12 @@ class Message implements MessageContract, Validatable
         return $map;
     }
 
+    public static function matchMessage(MessageContract $message): bool
+    {
+        //If a default message is matched this should return false at it wil
+        //trigger an override
+        return false;
+    }
 
     /**
      * @return bool
@@ -138,16 +155,18 @@ class Message implements MessageContract, Validatable
         return $this->subMessages;
     }
 
-    public static function matchMessage(MessageContract $message): bool
+    /**
+     * @return int
+     */
+    public function getSubMessagesCount(): int
     {
-        //If a default message is matched this should return false at it wil
-        //trigger an override
-        return false;
-    }
+        $count = 0;
 
-    public function hasEntity($label): bool
-    {
-        return isset($this->entities[$label]) && count($this->entities[$label]) > 0;
+        foreach ($this->subMessages as $subMessages) {
+            $count += count($subMessages);
+        }
+
+        return $count;
     }
 
     /**
@@ -169,6 +188,11 @@ class Message implements MessageContract, Validatable
         return !empty($result) && array_product($result);
     }
 
+    public function hasEntity($label): bool
+    {
+        return isset($this->entities[$label]) && count($this->entities[$label]) > 0;
+    }
+
     /**
      * @param $label
      * @param $entityLabel
@@ -186,5 +210,69 @@ class Message implements MessageContract, Validatable
         }
 
         return !empty($result) && array_product($result);
+    }
+
+    /**
+     * @return Carbon|null
+     */
+    public function getDateTime(): ?Carbon
+    {
+        return $this->dateTime;
+    }
+
+    /**
+     * @param Carbon $dateTime
+     */
+    public function setDateTime(Carbon $dateTime): void
+    {
+        $this->dateTime = $dateTime;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getMessageId(): ?string
+    {
+        return $this->messageId;
+    }
+
+    /**
+     * @param string $messageId
+     */
+    public function setMessageId(string $messageId): void
+    {
+        $this->messageId = $messageId;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getSender(): ?string
+    {
+        return $this->sender;
+    }
+
+    /**
+     * @param string $sender
+     */
+    public function setSender(string $sender): void
+    {
+        $this->sender = $sender;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getReceiver(): ?string
+    {
+        return $this->receiver;
+    }
+
+    /**
+     * @param string $receiver
+     */
+    public function setReceiver(string $receiver): void
+    {
+        $this->receiver = $receiver;
     }
 }

--- a/src/Repositories/Contracts/AttributeRepository.php
+++ b/src/Repositories/Contracts/AttributeRepository.php
@@ -16,9 +16,9 @@ interface AttributeRepository
     /**
      * @param $label
      * @param null $value
-     * @return Attribute
+     * @return Attribute|null
      */
-    public function getByLabel($label, $value = null): Attribute;
+    public function getByLabel($label, $value = null): ?Attribute;
 
     /**
      * @param Entity $entity

--- a/src/Repositories/Contracts/CodeListRepository.php
+++ b/src/Repositories/Contracts/CodeListRepository.php
@@ -14,7 +14,7 @@ interface CodeListRepository
 
     /**
      * @param $label
-     * @return CodeList
+     * @return CodeList|null
      */
-    public function findByLabel($label): CodeList;
+    public function findByLabel($label): ?CodeList;
 }

--- a/src/Repositories/Contracts/CodeRepository.php
+++ b/src/Repositories/Contracts/CodeRepository.php
@@ -17,5 +17,5 @@ interface CodeRepository
      * @param $code
      * @return Code
      */
-    public function findByCode($code): Code;
+    public function findByCode($code): ?Code;
 }

--- a/src/Repositories/Contracts/EntityRepository.php
+++ b/src/Repositories/Contracts/EntityRepository.php
@@ -16,7 +16,7 @@ interface EntityRepository
 
     /**
      * @param $label
-     * @return Entity
+     * @return Entity|null
      */
-    public function getByLabel($label): Entity;
+    public function getByLabel($label): ?Entity;
 }

--- a/src/Repositories/JSON/AttributeRepository.php
+++ b/src/Repositories/JSON/AttributeRepository.php
@@ -129,12 +129,12 @@ class AttributeRepository implements \SIVI\AFD\Repositories\Contracts\AttributeR
             }
         }
 
-        if (isset($data['Code']) && !empty($data['Code'])) {
-            $attribute->setCode($this->codeRepository->findByCode($data['Code']));
+        if (isset($data['Code']) && !empty($data['Code']) && ($code = $this->codeRepository->findByCode($data['Code'])) !== null) {
+            $attribute->setCode($code);
         }
 
-        if (isset($data['Codelijst']) && !empty($data['Codelijst'])) {
-            $attribute->setCodeList($this->codeListRepository->findByLabel($data['Codelijst']));
+        if (isset($data['Codelijst']) && !empty($data['Codelijst']) && ($codeList = $this->codeListRepository->findByLabel($data['Codelijst'])) !== null) {
+            $attribute->setCodeList($codeList);
         }
 
         return $attribute;

--- a/src/Repositories/JSON/CodeListRepository.php
+++ b/src/Repositories/JSON/CodeListRepository.php
@@ -38,7 +38,7 @@ class CodeListRepository implements \SIVI\AFD\Repositories\Contracts\CodeListRep
     /**
      * {@inheritDoc}
      */
-    public function findByLabel($label): CodeList
+    public function findByLabel($label): ?CodeList
     {
         $codeList = $this->instantiateObject($label);
 

--- a/src/Repositories/Model/CodeRepository.php
+++ b/src/Repositories/Model/CodeRepository.php
@@ -47,7 +47,7 @@ class CodeRepository implements \SIVI\AFD\Repositories\Contracts\CodeRepository
      * @return Code
      * @throws NotFoundException
      */
-    public function findByCode($code): Code
+    public function findByCode($code): ?Code
     {
         return $this->instantiateObject($code);
     }


### PR DESCRIPTION
- :rainbow: Add new Exception for EDI parser
- :art: Add nullable return types to repositories to take in account that some agencies might send incorrect data
- :art: Add prolongation and mutation to message type enum
- :art: Implement EDI exception
- :art: Add more info to Message model and interface
- :art: Refactor XML parser to work with nullable return types of repositories
- :art: Completely refactor EDI parser, fix edge cases, extract more message info, create message based on type, validation of parsed data and more